### PR TITLE
Consumer to handle OCR microservice's messages

### DIFF
--- a/src/main/java/com/studyforces/sourcesapi/controllers/OCRController.java
+++ b/src/main/java/com/studyforces/sourcesapi/controllers/OCRController.java
@@ -22,8 +22,7 @@ public class OCRController {
     @PostMapping("/request/{id}")
     SourceUpload requestOCR(@PathVariable Long id) throws Exception {
         SourceUpload upload = sourceUploadRepository.findById(id).orElseThrow();
-        this.ocrService.runOCR(upload);
-        return sourceUploadRepository.save(upload);
+        return this.ocrService.runOCR(upload);
     }
 
 }

--- a/src/main/java/com/studyforces/sourcesapi/models/SourceUploadRect.java
+++ b/src/main/java/com/studyforces/sourcesapi/models/SourceUploadRect.java
@@ -1,6 +1,13 @@
 package com.studyforces.sourcesapi.models;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.studyforces.sourcesapi.support.JpaConverterJson;
+
+import javax.persistence.Convert;
 import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+import java.util.Map;
+import java.util.Objects;
 
 @Embeddable
 public class SourceUploadRect {
@@ -63,5 +70,29 @@ public class SourceUploadRect {
 
     public void setStatus(SourceUploadRectStatus status) {
         this.status = status;
+    }
+
+    private Object data;
+
+    @Convert(converter = JpaConverterJson.class)
+    public Object getData() {
+        return data;
+    }
+
+    public void setData(Object data) {
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SourceUploadRect that = (SourceUploadRect) o;
+        return getX().equals(that.getX()) && getY().equals(that.getY()) && getWidth().equals(that.getWidth()) && getHeight().equals(that.getHeight()) && getType() == that.getType();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getX(), getY(), getWidth(), getHeight(), getType());
     }
 }

--- a/src/main/java/com/studyforces/sourcesapi/models/SourceUploadRectStatus.java
+++ b/src/main/java/com/studyforces/sourcesapi/models/SourceUploadRectStatus.java
@@ -1,5 +1,5 @@
 package com.studyforces.sourcesapi.models;
 
 public enum SourceUploadRectStatus {
-    PENDING, FAILED, SUCCEED
+    PENDING, DONE
 }

--- a/src/main/java/com/studyforces/sourcesapi/services/OCRService.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/OCRService.java
@@ -3,40 +3,69 @@ package com.studyforces.sourcesapi.services;
 import com.studyforces.sourcesapi.models.SourceUpload;
 import com.studyforces.sourcesapi.models.SourceUploadRect;
 import com.studyforces.sourcesapi.models.SourceUploadRectStatus;
+import com.studyforces.sourcesapi.repositories.SourceUploadRepository;
+import com.studyforces.sourcesapi.services.messages.OCRDataText;
+import com.studyforces.sourcesapi.services.messages.OCRRequestMessage;
+import com.studyforces.sourcesapi.services.messages.OCRResponseMessage;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 @Service
 public class OCRService {
 
-    OCRService(FileService fileService) {
+    OCRService(FileService fileService, SourceUploadRepository sourceUploadRepository) {
         this.fileService = fileService;
+        this.sourceUploadRepository = sourceUploadRepository;
     }
 
     FileService fileService;
+    SourceUploadRepository sourceUploadRepository;
 
-    BlockingQueue<OCRMessage> unboundedTexts = new LinkedBlockingQueue<>();
+    BlockingQueue<OCRRequestMessage> unboundedTexts = new LinkedBlockingQueue<>();
 
-    public void runOCR(SourceUpload upload) throws Exception {
+    public SourceUpload runOCR(@NotNull SourceUpload upload) throws Exception {
         List<SourceUploadRect> rects = upload.getRects().stream().toList();
 
         for (SourceUploadRect rect : rects) {
             rect.setStatus(SourceUploadRectStatus.PENDING);
-            OCRMessage msg = new OCRMessage();
+            OCRRequestMessage msg = new OCRRequestMessage();
             msg.setSourceUploadID(upload.getId());
             msg.setSourceUploadURL(fileService.objectURL(upload.getSourceFile()));
             unboundedTexts.offer(msg);
         }
+
+        this.sourceUploadRepository.save(upload);
+
+        return upload;
     }
 
     @Bean
-    public Supplier<OCRMessage> textSupplier() {
+    public Supplier<OCRRequestMessage> textSupplier() {
         return () -> unboundedTexts.poll();
+    }
+
+    @Bean
+    public Consumer<OCRResponseMessage<OCRDataText>> textSink() {
+        return msg -> {
+            SourceUpload upload = this.sourceUploadRepository.findById(msg.getSourceUploadID()).orElseThrow();
+
+            for (SourceUploadRect rect : upload.getRects()) {
+                if (rect.equals(msg.getRect())) {
+                    rect.setStatus(SourceUploadRectStatus.DONE);
+                    rect.setData(msg.getData());
+                    break;
+                }
+            }
+
+            this.sourceUploadRepository.save(upload);
+        };
     }
 
 }

--- a/src/main/java/com/studyforces/sourcesapi/services/messages/OCRDataText.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/messages/OCRDataText.java
@@ -1,0 +1,13 @@
+package com.studyforces.sourcesapi.services.messages;
+
+public class OCRDataText {
+    private String text;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/src/main/java/com/studyforces/sourcesapi/services/messages/OCRRequestMessage.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/messages/OCRRequestMessage.java
@@ -1,0 +1,35 @@
+package com.studyforces.sourcesapi.services.messages;
+
+import com.studyforces.sourcesapi.models.SourceUploadRect;
+
+public class OCRRequestMessage {
+    private Long sourceUploadID;
+
+    public Long getSourceUploadID() {
+        return sourceUploadID;
+    }
+
+    public void setSourceUploadID(Long sourceUploadID) {
+        this.sourceUploadID = sourceUploadID;
+    }
+
+    private String sourceUploadURL;
+
+    public String getSourceUploadURL() {
+        return sourceUploadURL;
+    }
+
+    public void setSourceUploadURL(String sourceUploadURL) {
+        this.sourceUploadURL = sourceUploadURL;
+    }
+
+    private SourceUploadRect rect;
+
+    public SourceUploadRect getRect() {
+        return rect;
+    }
+
+    public void setRect(SourceUploadRect rect) {
+        this.rect = rect;
+    }
+}

--- a/src/main/java/com/studyforces/sourcesapi/services/messages/OCRResponseMessage.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/messages/OCRResponseMessage.java
@@ -1,8 +1,8 @@
-package com.studyforces.sourcesapi.services;
+package com.studyforces.sourcesapi.services.messages;
 
 import com.studyforces.sourcesapi.models.SourceUploadRect;
 
-public class OCRMessage {
+public class OCRResponseMessage<T> {
     private Long sourceUploadID;
 
     public Long getSourceUploadID() {
@@ -13,16 +13,6 @@ public class OCRMessage {
         this.sourceUploadID = sourceUploadID;
     }
 
-    private String sourceUploadURL;
-
-    public String getSourceUploadURL() {
-        return sourceUploadURL;
-    }
-
-    public void setSourceUploadURL(String sourceUploadURL) {
-        this.sourceUploadURL = sourceUploadURL;
-    }
-
     private SourceUploadRect rect;
 
     public SourceUploadRect getRect() {
@@ -31,5 +21,15 @@ public class OCRMessage {
 
     public void setRect(SourceUploadRect rect) {
         this.rect = rect;
+    }
+
+    private T data;
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
     }
 }

--- a/src/main/java/com/studyforces/sourcesapi/support/JpaConverterJson.java
+++ b/src/main/java/com/studyforces/sourcesapi/support/JpaConverterJson.java
@@ -1,0 +1,35 @@
+package com.studyforces.sourcesapi.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.io.IOException;
+
+@Converter(autoApply = true)
+public class JpaConverterJson implements AttributeConverter<Object, String> {
+
+    private final static ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Object meta) {
+        try {
+            return objectMapper.writeValueAsString(meta);
+        } catch (JsonProcessingException ex) {
+            return null;
+            // or throw an error
+        }
+    }
+
+    @Override
+    public Object convertToEntityAttribute(String dbData) {
+        try {
+            return objectMapper.readValue(dbData, Object.class);
+        } catch (IOException ex) {
+            // logger.error("Unexpected IOEx decoding json from database: " + dbData);
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
## What's done?

* Added `Consumer` to handle messages from OCR microservice through RabbitMQ.
* Store `data` from OCR inside `SourceUploadRect`
* Added `JpaConverter` to handle `java.lang.Object` and store it in the database as JSON (may be buggy, should be covered with tests, see #1)

## Related issues
* #2