### PR TITLE
Multiple source files support

### DIFF
--- a/src/main/java/com/studyforces/sourcesapi/controllers/UploadsController.java
+++ b/src/main/java/com/studyforces/sourcesapi/controllers/UploadsController.java
@@ -47,7 +47,7 @@ public class UploadsController {
     }
 
     @PostMapping
-    SourceUpload saveSource(@RequestBody SaveSourceRequest req) throws Exception {
+    SourceUpload saveSource(@RequestBody SaveSourceRequest req) {
         for (String fileName : req.getFileNames()) {
             if (!fileService.fileExists(fileName)) {
                 throw new ResourceNotFoundException();
@@ -81,6 +81,25 @@ public class UploadsController {
     @GetMapping("/{id}")
     public SourceUpload findById(@PathVariable Long id) {
         return sourceUploadRepository.findById(id).orElseThrow(ResourceNotFoundException::new);
+    }
+
+    @PutMapping("/{id}")
+    public SourceUpload setSourceFiles(@PathVariable Long id, @RequestBody SaveSourceRequest req) {
+        SourceUpload upload = sourceUploadRepository.findById(id).orElseThrow(ResourceNotFoundException::new);
+
+        List<SourceUploadFile> files = new ArrayList<>();
+        for (int i = 0; i < req.getFileNames().size(); i++) {
+            String file = req.getFileNames().get(i);
+            SourceUploadFile f = new SourceUploadFile();
+            f.setFile(file);
+            f.setOrder(i);
+        }
+
+        upload.setSourceFiles(files);
+
+        sourceService.process(upload);
+
+        return upload;
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/studyforces/sourcesapi/controllers/UploadsController.java
+++ b/src/main/java/com/studyforces/sourcesapi/controllers/UploadsController.java
@@ -1,7 +1,6 @@
 package com.studyforces.sourcesapi.controllers;
 
 import com.studyforces.sourcesapi.models.OCRResult;
-import com.studyforces.sourcesapi.models.OCRResultStatus;
 import com.studyforces.sourcesapi.models.SourceUpload;
 import com.studyforces.sourcesapi.models.SourceUploadFile;
 import com.studyforces.sourcesapi.repositories.OCRResultRepository;
@@ -11,7 +10,6 @@ import com.studyforces.sourcesapi.requests.UpdateSourceUploadOCRRequest;
 import com.studyforces.sourcesapi.responses.FileInfoResponse;
 import com.studyforces.sourcesapi.services.FileService;
 import com.studyforces.sourcesapi.services.SourceService;
-import com.studyforces.sourcesapi.services.messages.sourceProcess.FileInfo;
 import io.minio.StatObjectResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/studyforces/sourcesapi/models/SourceUpload.java
+++ b/src/main/java/com/studyforces/sourcesapi/models/SourceUpload.java
@@ -19,6 +19,17 @@ public class SourceUpload {
         return id;
     }
 
+    @Basic
+    private String sourceFile;
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public void setSourceFile(String sourceFile) {
+        this.sourceFile = sourceFile;
+    }
+
     @ElementCollection
     @OrderBy("order")
     private List<SourceUploadFile> sourceFiles;

--- a/src/main/java/com/studyforces/sourcesapi/models/SourceUpload.java
+++ b/src/main/java/com/studyforces/sourcesapi/models/SourceUpload.java
@@ -19,15 +19,16 @@ public class SourceUpload {
         return id;
     }
 
-    @Basic
-    private String sourceFile;
+    @ElementCollection
+    @OrderBy("order")
+    private List<SourceUploadFile> sourceFiles;
 
-    public String getSourceFile() {
-        return sourceFile;
+    public List<SourceUploadFile> getSourceFiles() {
+        return sourceFiles;
     }
 
-    public void setSourceFile(String sourceFile) {
-        this.sourceFile = sourceFile;
+    public void setSourceFiles(List<SourceUploadFile> sourceFiles) {
+        this.sourceFiles = sourceFiles;
     }
 
     @OneToMany(mappedBy = "sourceUpload", cascade = CascadeType.ALL)

--- a/src/main/java/com/studyforces/sourcesapi/models/SourceUploadFile.java
+++ b/src/main/java/com/studyforces/sourcesapi/models/SourceUploadFile.java
@@ -1,0 +1,12 @@
+package com.studyforces.sourcesapi.models;
+
+import lombok.Data;
+
+import javax.persistence.Embeddable;
+
+@Data
+@Embeddable
+public class SourceUploadFile {
+    private String file;
+    private Integer order;
+}

--- a/src/main/java/com/studyforces/sourcesapi/requests/SaveSourceRequest.java
+++ b/src/main/java/com/studyforces/sourcesapi/requests/SaveSourceRequest.java
@@ -1,13 +1,15 @@
 package com.studyforces.sourcesapi.requests;
 
-public class SaveSourceRequest {
-    private String fileName;
+import java.util.List;
 
-    public String getFileName() {
-        return this.fileName;
+public class SaveSourceRequest {
+    private List<String> fileNames;
+
+    public List<String> getFileNames() {
+        return this.fileNames;
     }
 
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
+    public void setFileNames(List<String> fileNames) {
+        this.fileNames = fileNames;
     }
 }

--- a/src/main/java/com/studyforces/sourcesapi/services/SourceService.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/SourceService.java
@@ -38,11 +38,11 @@ public class SourceService {
     public void process(SourceUpload upload) {
         SourceMetadataRequest req = new SourceMetadataRequest();
 
+        upload.setMetadata(null);
+        sourceUploadRepository.save(upload);
+
         req.setSourceUploadID(upload.getId());
         req.setFileInfos(getFileInfo(upload.getSourceFiles()));
-        upload.setMetadata(null);
-
-        sourceUploadRepository.save(upload);
 
         unboundedMetadataRequests.offer(req);
     }

--- a/src/main/java/com/studyforces/sourcesapi/services/SourceService.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/SourceService.java
@@ -35,11 +35,14 @@ public class SourceService {
     BlockingQueue<SourceMetadataRequest> unboundedMetadataRequests = new LinkedBlockingQueue<>();
     BlockingQueue<SourceConversionRequest> unboundedConvertRequests = new LinkedBlockingQueue<>();
 
-    public void process(SourceUpload upload) throws Exception {
+    public void process(SourceUpload upload) {
         SourceMetadataRequest req = new SourceMetadataRequest();
 
         req.setSourceUploadID(upload.getId());
         req.setFileInfos(getFileInfo(upload.getSourceFiles()));
+        upload.setMetadata(null);
+
+        sourceUploadRepository.save(upload);
 
         unboundedMetadataRequests.offer(req);
     }

--- a/src/main/java/com/studyforces/sourcesapi/services/messages/sourceProcess/FileInfo.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/messages/sourceProcess/FileInfo.java
@@ -1,0 +1,12 @@
+package com.studyforces.sourcesapi.services.messages.sourceProcess;
+
+import com.studyforces.sourcesapi.responses.FileInfoResponse;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FileInfo {
+    private String url;
+    private FileInfoResponse fileInfo;
+}

--- a/src/main/java/com/studyforces/sourcesapi/services/messages/sourceProcess/SourceConversionRequest.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/messages/sourceProcess/SourceConversionRequest.java
@@ -1,7 +1,6 @@
 package com.studyforces.sourcesapi.services.messages.sourceProcess;
 
 import com.studyforces.sourcesapi.models.SourceMetadata;
-import com.studyforces.sourcesapi.responses.FileInfoResponse;
 import com.studyforces.sourcesapi.responses.FileUploadResponse;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,9 +10,8 @@ import java.util.List;
 @Getter
 @Setter
 public class SourceConversionRequest {
-    private String url;
     private Long sourceUploadID;
     private SourceMetadata metadata;
-    private FileInfoResponse fileInfo;
+    private List<FileInfo> fileInfos;
     private List<FileUploadResponse> uploadURLs;
 }

--- a/src/main/java/com/studyforces/sourcesapi/services/messages/sourceProcess/SourceMetadataRequest.java
+++ b/src/main/java/com/studyforces/sourcesapi/services/messages/sourceProcess/SourceMetadataRequest.java
@@ -1,13 +1,13 @@
 package com.studyforces.sourcesapi.services.messages.sourceProcess;
 
-import com.studyforces.sourcesapi.responses.FileInfoResponse;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
 public class SourceMetadataRequest {
-    private String url;
     private Long sourceUploadID;
-    private FileInfoResponse fileInfo;
+    private List<FileInfo> fileInfos;
 }


### PR DESCRIPTION
Fixes #12 

* Leaving `sourceFile` for transition
* Adding `sourceFiles` array of files
* Updating endpoints to work with the changes above
* Breaking changes in the sources microservices communication layer (upload processing won't work until changes in metadata and conversion microservices)